### PR TITLE
Fixed wrong suggested install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Grafana integration for Humio
 
 # Installing the plugin
 -   clone the repo
--   copy dist folder (or the whole repo) to /var/lib/grafana/data/plugins
+-   copy dist folder (or the whole repo) to /var/lib/grafana/plugins
 -   restart grafana
 
 # Setting up Humio datasource


### PR DESCRIPTION
In reference to #33 

The suggested install location in the README is inconsistent. In the `Installing the plugin` section, it says `/var/lib/grafana/data/plugins` and later in the `Development` section `/usr/local/var/lib/grafana/plugins`. I think the `data` subdir in the first suggested path is wrong, at least according to current Grafana defaults. The official Grafana docker image has them in `/var/lib/grafana/plugins`.