### PR TITLE
Update README and configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Grafana integration for Humio
 -   click "add datasouce"
 -   select datasource type "humio2grafana"
 -   set datasource name, for example "Humio cloud"
--   set humio server address without trailing slash, for example https://cloud.humio.com
+-   set humio server address, for example `https://cloud.humio.com`
 -   set "Humio access token" to some active token
 -   click "Save & Test" button, you chould receive "success" message
 
@@ -79,8 +79,7 @@ cp -R dist /usr/local/var/lib/grafana/plugins/humio2grafana
 Or create a symlink to avoid having to copy the `dist` directory every time a change has been made:
 
 ```bash
-cd /usr/local/var/lib/grafana/plugins/
-ln -s ~/code/humio/humio2grafana/dist humio2grafana
+ln -s $(pwd)/dist /usr/local/var/lib/grafana/plugins/humio2grafana
 brew services restart grafana
 ```
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -13,7 +13,7 @@ Grafana integration for Humio
 -   click "add datasouce"
 -   select datasource type "humio2grafana"
 -   set datasource name, for example "Humio cloud"
--   set humio server address without trailing slash, for example https://cloud.humio.com
+-   set humio server address, for example `https://cloud.humio.com`
 -   set "Humio access token" to some active token
 -   click "Save & Test" button, you chould receive "success" message
 

--- a/dist/partials/config.html
+++ b/dist/partials/config.html
@@ -1,1 +1,1 @@
-<datasource-http-settings current="ctrl.current" suggest-url="https://cloud.humio.com/"></datasource-http-settings><h5>Humio access token</h5><div class="gf-form"><input class="gf-form-input" type="text" ng-model="ctrl.current.jsonData.humioToken" placeholder=""/></div>
+<datasource-http-settings current="ctrl.current" suggest-url="https://cloud.humio.com"></datasource-http-settings><h5>Humio access token</h5><div class="gf-form"><input class="gf-form-input" type="text" ng-model="ctrl.current.jsonData.humioToken" placeholder=""/></div>

--- a/src/README.md
+++ b/src/README.md
@@ -13,7 +13,7 @@ Grafana integration for Humio
 -   click "add datasouce"
 -   select datasource type "humio2grafana"
 -   set datasource name, for example "Humio cloud"
--   set humio server address without trailing slash, for example https://cloud.humio.com
+-   set humio server address, for example `https://cloud.humio.com`
 -   set "Humio access token" to some active token
 -   click "Save & Test" button, you chould receive "success" message
 

--- a/src/partials/config.pug
+++ b/src/partials/config.pug
@@ -1,4 +1,4 @@
-datasource-http-settings(current="ctrl.current", suggest-url="https://cloud.humio.com/")
+datasource-http-settings(current="ctrl.current", suggest-url="https://cloud.humio.com")
 h5 Humio access token
 .gf-form
   input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.humioToken', placeholder="")


### PR DESCRIPTION
- Simplifies Humio server address (slash doesn't matter, see https://github.com/humio/humio2grafana/blob/34ebfa8a5745b6751425dae55f40bbdedcead451/src/datasource.ts#L36)
- Removes trailing slash from example config
- Updates symlink code to work if directory structure is different