### PR TITLE
Add CI (GitHub actions)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - '**'
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [8, 10, 12]
+    env:
+      CI: true
+    steps:
+    - name: Checkout ${{ github.sha }}
+      uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: npm ci
+    - name: Build
+      run: npm run build
+    - name: Ensure no git changes after build (keep src and dist in sync)
+      run: |
+        git add .
+        NUMBER_OF_FILES_CHANGED=$(git diff --name-only HEAD | wc -l)
+        if [[ $NUMBER_OF_FILES_CHANGED -gt 0 ]]; then exit 1; fi


### PR DESCRIPTION
Just checks that it at least builds on different node versions, and that the `dist` folder isn't out of sync with `src`. Think `npm test` is broken at the moment so haven't added them to the CI yet.