### PR TITLE
Token Encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,14 @@ Major refactoring of codebase.
 
 ### Removed
 - Many smaller unused files.
+
+## 2.0.0 (2020-04-16)
+Update to Datasource Configuration. This update requires existing data sources to be set up again.
+### Added 
+- Encryption of Humio access token on backend. Now all Humio calls are proxied through the Grafana backend, meaning that access tokens are no longer accessible to users in the frontend. This also means that Humio queries can no longer be made through the browser directly.
+
+### Changed
+- Fixed bug where humio query links would not work, if the datasource URL did not have a trailing slash.
+
+### Removed
+- Some standard data source configuration options. These had to be removed in order to configure datasources for encrypted access tokens.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "humio2grafana",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "humio2grafana",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "Humio datasouce for grafana",
   "main": "dist/module",
   "scripts": {

--- a/specs/datasource_specs.ts
+++ b/specs/datasource_specs.ts
@@ -11,7 +11,7 @@ var testRespSimpleGauge = readJSON('specs/assets/test_response_simple_gauge.json
 function mockApiCallsForQueryJobs(ctx, expected_payload){
   ctx.backendSrv.datasourceRequest = (request) => {
     // Mocking out API call for creating a query job
-    if (request.url === "https://cloud.humio.com/api/v1/dataspaces/humio/queryjobs") {
+    if (request.url === "http://localhost:4000/api/datasources/proxy/1/humio/api/v1/dataspaces/humio/queryjobs") {
       return ctx.$q.resolve({
         _request: request,
         data: {id: "wZXe96fINr7ZktsEvb4utIp2"}
@@ -32,10 +32,10 @@ describe('HumioDatasource', function() {
     backendSrv: {},
   };
 
-  // Sets up the HumopDatasource used by all tests.
+  // Sets up the HumoiDatasource used by all tests.
   beforeEach(function() {
     ctx.$q = Q;
-    ctx.instanceSettings = {url: "https://cloud.humio.com", id:1};
+    ctx.instanceSettings = {url: "http://localhost:4000/api/datasources/proxy/1", id:1};
     ctx.$location = { search() {return true }}
     // $rootScope has not been mocked, may create issues when tests need to use it.  
     ctx.ds = new HumioDatasource(ctx.instanceSettings, ctx.$q, ctx.backendSrv, ctx.$location, {});

--- a/specs/datasource_specs.ts
+++ b/specs/datasource_specs.ts
@@ -32,7 +32,7 @@ describe('HumioDatasource', function() {
     backendSrv: {},
   };
 
-  // Sets up the HumoiDatasource used by all tests.
+  // Sets up the HumioDatasource used by all tests.
   beforeEach(function() {
     ctx.$q = Q;
     ctx.instanceSettings = {url: "http://localhost:4000/api/datasources/proxy/1", id:1};

--- a/src/Interfaces/IDatasource.ts
+++ b/src/Interfaces/IDatasource.ts
@@ -1,12 +1,10 @@
 import IDatasourceAttrs from './IDatasourceAttrs';
-import IDatasourceRequestHeaders from './IDatasourceRequestHeaders'
 
 
 interface IDatasource {
     id: string,
-    url: string,
+    proxy_url: string,
     datasourceAttrs: IDatasourceAttrs,
-    headers: IDatasourceRequestHeaders,
     timeRange: {
       from: any, // Moment
       to: any, // Moment

--- a/src/Interfaces/IDatasourceAttrs.ts
+++ b/src/Interfaces/IDatasourceAttrs.ts
@@ -4,7 +4,7 @@ interface IDatasourceAttrs {
   $q: any;
   $location: any;
   backendSrv: {
-    datasourceRequest: (options: any) => Promise<{
+    datasourceRequest: (options: IDatasourceRequestOptions) => Promise<{
         data: any;
         [key: string]: any;
     }>;

--- a/src/Interfaces/IDatasourceAttrs.ts
+++ b/src/Interfaces/IDatasourceAttrs.ts
@@ -4,7 +4,7 @@ interface IDatasourceAttrs {
   $q: any;
   $location: any;
   backendSrv: {
-    datasourceRequest: (options: IDatasourceRequestOptions) => Promise<{
+    datasourceRequest: (options: any) => Promise<{
         data: any;
         [key: string]: any;
     }>;

--- a/src/Interfaces/IDatasourceRequestHeaders.ts
+++ b/src/Interfaces/IDatasourceRequestHeaders.ts
@@ -1,6 +1,0 @@
-interface IDatasourceRequestHeaders {
-    'Content-Type': string;
-    Authorization: string;
-}
-
-export default IDatasourceRequestHeaders;

--- a/src/Interfaces/IDatasourceRequestOptions.ts
+++ b/src/Interfaces/IDatasourceRequestOptions.ts
@@ -1,9 +1,6 @@
-import IDatasourceRequestHeaders from './IDatasourceRequestHeaders';
-
 interface DatasourceRequestOptions {
     method: string;
     url: string;
-    headers: IDatasourceRequestHeaders;
     data?: {
         [key: string]: any;
     };

--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -5,9 +5,7 @@ export class HumioConfigCtrl {
   constructor() {
     this.current = this.current || {};
     this.current.jsonData = this.current.jsonData || {};
-    this.current.jsonData.baseUrl = this.current.url || "";
-    this.current.secureJsonData = this.current.secureJsonData || {};
-    this.current.secureJsonData.humioToken = this.current.secureJsonData.humioToken || "";
+    this.current.jsonData.baseUrl = this.current.jsonData.baseUrl || "";
   }
 }
 

--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -5,7 +5,9 @@ export class HumioConfigCtrl {
   constructor() {
     this.current = this.current || {};
     this.current.jsonData = this.current.jsonData || {};
-    this.current.jsonData.humioToken = this.current.jsonData.humioToken || "";
+    this.current.jsonData.baseUrl = this.current.url || "";
+    this.current.secureJsonData = this.current.secureJsonData || {};
+    this.current.secureJsonData.humioToken = this.current.secureJsonData.humioToken || "";
   }
 }
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -77,7 +77,7 @@ export class HumioDatasource {
     }
 
     return this.datasourceAttrs.backendSrv
-      .datasourceRequest(requestOpts)
+      .datasourceRequest({url: this.url + "/humio/graphql", method: "POST", data: { query: '{currentUser{id}}' }})
         .then(response => {
           if (response.data.data != null) {
             return {
@@ -104,8 +104,7 @@ export class HumioDatasource {
   }
 
   private _doRequest(options) {
-    options.headers = this.headers;
-    options.url = this.url + options.url;
+    options.url = this.url + "/humio" + options.url;
     return this.datasourceAttrs.backendSrv.datasourceRequest(options);
   }
 }

--- a/src/humio/query_job_manager.ts
+++ b/src/humio/query_job_manager.ts
@@ -42,7 +42,8 @@ class QueryJobManager {
     let allQueryPromise = targets.map((target: ITarget, index: number) => 
     {
       let query = this._getOrCreateQueryJob(index, target.humioQuery);
-      return query.executeQuery(datasourceAttrs, grafanaAttrs, target);
+      let res = query.executeQuery(datasourceAttrs, grafanaAttrs, target);
+      return res;
     });
 
     return Promise.all(allQueryPromise);

--- a/src/partials/config.pug
+++ b/src/partials/config.pug
@@ -4,4 +4,6 @@ h5 Humio Url
 
 h5 Humio Access Token
 .gf-form
-  input.gf-form-input(type="text", ng-model='ctrl.current.secureJsonData.humioToken')
+  input.gf-form-input(type="text",   tooltip="Grafana Proxy deletes fo",  ng-model='ctrl.current.secureJsonData.humioToken')
+
+p Once the datasource is saved the contents of the 'Humio Access Token' field will be hidden. The datasource will continue to use the submitted token until it is changed. 

--- a/src/partials/config.pug
+++ b/src/partials/config.pug
@@ -1,4 +1,7 @@
-datasource-http-settings(current="ctrl.current", suggest-url="https://cloud.humio.com")
-h5 Humio access token
+h5 Humio Url
 .gf-form
-  input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.humioToken', placeholder="")
+  input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.baseUrl', placeholder="https://cloud.humio.com")
+
+h5 Humio Access Token
+.gf-form
+  input.gf-form-input(type="text", ng-model='ctrl.current.secureJsonData.humioToken', placeholder="")

--- a/src/partials/config.pug
+++ b/src/partials/config.pug
@@ -4,4 +4,4 @@ h5 Humio Url
 
 h5 Humio Access Token
 .gf-form
-  input.gf-form-input(type="text", ng-model='ctrl.current.secureJsonData.humioToken', placeholder="")
+  input.gf-form-input(type="text", ng-model='ctrl.current.secureJsonData.humioToken')

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -22,6 +22,15 @@
     "version": "1.0.5",
     "updated": "2018-11-28"
   },
+  "routes": [{
+    "path": "humio",
+    "method": "*",
+    "url": "{{.JsonData.baseUrl}}",
+    "headers": [
+      {"name": "Authorization", "content": "Bearer {{.SecureJsonData.humioToken}}"},
+      {"name": "Content-Type", "content" : "application/json"}
+    ]
+  }],
   "dependencies": {
     "grafanaVersion": "5.x.x",
     "plugins": [ ]

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -19,8 +19,8 @@
       {"name": "GitHub", "url": "https://github.com/humio/humio2grafana"},
       {"name": "Apache License", "url": "https://github.com/humio/humio2grafana/blob/master/LICENSE.md"}
     ],
-    "version": "1.0.5",
-    "updated": "2018-11-28"
+    "version": "2.0.0",
+    "updated": "2020-16-04"
   },
   "routes": [{
     "path": "humio",

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -32,7 +32,7 @@ class HumioQueryCtrl extends QueryCtrl {
     this.$q = $q;
     this.$location = $location;
 
-    this.target.humioQuery = this.target.humioQuery || undefined;
+    this.target.humioQuery = this.target.humioQuery || 'timechart()';
     this.target.humioRepository = this.target.humioRepository || "";
 
     this.hostUrl = '';

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -67,13 +67,13 @@ class HumioQueryCtrl extends QueryCtrl {
   }
 
   private _getHumioRepositories() {
-    if (!this.datasource.url) {
+    if (!this.datasource.proxy_url) {
       return this.$q.when([]);
     }
 
-    const requestOpts: any = {
+    const requestOpts: IDatasourceRequestOptions = {
       method: 'POST',
-      url: this.datasource.url + "/humio/graphql",
+      url: this.datasource.proxy_url + "/humio/graphql",
       data: { query: '{searchDomains{name}}' },
     }
 

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -32,8 +32,8 @@ class HumioQueryCtrl extends QueryCtrl {
     this.$q = $q;
     this.$location = $location;
 
-    this.target.humioQuery = this.target.humioQuery || 'timechart()';
-    this.target.humioRepository = this.target.humioRepository || undefined;
+    this.target.humioQuery = this.target.humioQuery || undefined;
+    this.target.humioRepository = this.target.humioRepository || "";
 
     this.hostUrl = '';
     $http({
@@ -71,10 +71,9 @@ class HumioQueryCtrl extends QueryCtrl {
       return this.$q.when([]);
     }
 
-    const requestOpts: IDatasourceRequestOptions = {
+    const requestOpts: any = {
       method: 'POST',
-      url: this.datasource.url + '/graphql',
-      headers: this.datasource.headers,
+      url: this.datasource.url + "/humio/graphql",
       data: { query: '{searchDomains{name}}' },
     }
 

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -41,6 +41,10 @@ class HumioQueryCtrl extends QueryCtrl {
       method: 'GET',
     }).then(res => {
       this.hostUrl = res.data.jsonData.baseUrl;
+      // Trim off the last / if it exists. Otherwise later url concatinations will be incorrect.
+      if(this.hostUrl[this.hostUrl.length - 1] === "/"){
+        this.hostUrl = this.hostUrl.substring(0, this.hostUrl.length - 1);
+      }
     });
 
     this._getHumioRepositories().then(repositories => {
@@ -53,7 +57,7 @@ class HumioQueryCtrl extends QueryCtrl {
       return '#';
     } else {
       let queryParams = this._composeQueryArgs();
-      return `${this.hostUrl}${this.target.humioRepository}/search?${this._serializeQueryArgs(queryParams)}`
+      return `${this.hostUrl}/${this.target.humioRepository}/search?${this._serializeQueryArgs(queryParams)}`
     }
   }
 

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -40,7 +40,7 @@ class HumioQueryCtrl extends QueryCtrl {
       url: '/api/datasources/' + this.datasource.id,
       method: 'GET',
     }).then(res => {
-      this.hostUrl = res.data.url;
+      this.hostUrl = res.data.jsonData.baseUrl;
     });
 
     this._getHumioRepositories().then(repositories => {


### PR DESCRIPTION
# <Feature Title>

Link To Issue Being Solved: https://github.com/humio/humio2grafana/issues/17

**What Changes Have Been Made?**
All requests to Humio datasources are now routed through the Grafana backend. This allows for tokens to be hid away in an encrypted format on the backend instead of being visible to users in the frontend.

Describe what changes your contribution introduces to the code base.
Plugin.json has had new routes added to it, and code considering the configuration of data sources has been touched.

**Why Have the Changes Been Made?**
By not encrypting the tokens, any user with access to a dashboard in their browser can use browser dev toolkits to inspect network traffic and fetch the Humio access token. By not having the token accessible in the frontend, this can no longer happen.

**How Do These Changes Impact the User?**
Users will have to update their data sources, as the way they are configured has changed. But this only requires the input of a URL hosting Humio and a token for each datasource.
