### PR TITLE
Reintroduce oauth

### DIFF
--- a/specs/datasource_specs.ts
+++ b/specs/datasource_specs.ts
@@ -35,7 +35,7 @@ describe('HumioDatasource', function() {
   // Sets up the HumioDatasource used by all tests.
   beforeEach(function() {
     ctx.$q = Q;
-    ctx.instanceSettings = {url: "http://localhost:4000/api/datasources/proxy/1", id:1, jsonData: {tokenAuth : true}};
+    ctx.instanceSettings = {url: "http://localhost:4000/api/datasources/proxy/1", id:1, jsonData: {authenticateWithAToken : true}};
     ctx.$location = { search() {return true }}
     // $rootScope has not been mocked, may create issues when tests need to use it.  
     ctx.ds = new HumioDatasource(ctx.instanceSettings, ctx.$q, ctx.backendSrv, ctx.$location, {});

--- a/specs/datasource_specs.ts
+++ b/specs/datasource_specs.ts
@@ -35,7 +35,7 @@ describe('HumioDatasource', function() {
   // Sets up the HumioDatasource used by all tests.
   beforeEach(function() {
     ctx.$q = Q;
-    ctx.instanceSettings = {url: "http://localhost:4000/api/datasources/proxy/1", id:1};
+    ctx.instanceSettings = {url: "http://localhost:4000/api/datasources/proxy/1", id:1, jsonData: {tokenAuth : true}};
     ctx.$location = { search() {return true }}
     // $rootScope has not been mocked, may create issues when tests need to use it.  
     ctx.ds = new HumioDatasource(ctx.instanceSettings, ctx.$q, ctx.backendSrv, ctx.$location, {});

--- a/src/Interfaces/IDatasource.ts
+++ b/src/Interfaces/IDatasource.ts
@@ -5,6 +5,8 @@ interface IDatasource {
     id: string,
     proxy_url: string,
     datasourceAttrs: IDatasourceAttrs,
+    tokenAuth: any,
+    headers: any,
     timeRange: {
       from: any, // Moment
       to: any, // Moment

--- a/src/Interfaces/IDatasource.ts
+++ b/src/Interfaces/IDatasource.ts
@@ -5,7 +5,7 @@ interface IDatasource {
     id: string,
     proxy_url: string,
     datasourceAttrs: IDatasourceAttrs,
-    tokenAuth: any,
+    authenticateWithAToken: boolean,
     headers: any,
     timeRange: {
       from: any, // Moment

--- a/src/Interfaces/IDatasourceRequestHeaders.ts
+++ b/src/Interfaces/IDatasourceRequestHeaders.ts
@@ -1,0 +1,7 @@
+
+interface IDatasourceRequestHeaders {
+    'Content-Type': string;
+    Authorization: string;
+}
+
+export default IDatasourceRequestHeaders;

--- a/src/Interfaces/IDatasourceRequestHeaders.ts
+++ b/src/Interfaces/IDatasourceRequestHeaders.ts
@@ -1,7 +1,6 @@
 
 interface IDatasourceRequestHeaders {
     'Content-Type': string;
-    Authorization: string;
 }
 
 export default IDatasourceRequestHeaders;

--- a/src/Interfaces/IDatasourceRequestOptions.ts
+++ b/src/Interfaces/IDatasourceRequestOptions.ts
@@ -1,6 +1,7 @@
 interface DatasourceRequestOptions {
     method: string;
     url: string;
+    headers?: any;
     data?: {
         [key: string]: any;
     };

--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -6,7 +6,7 @@ export class HumioConfigCtrl {
     this.current = this.current || {};
     this.current.jsonData = this.current.jsonData || {};
     this.current.jsonData.baseUrl = this.current.jsonData.baseUrl || "";
-    this.current.jsonData.tokenAuth = this.current.jsonData.authenticateWithAToken || false;
+    this.current.jsonData.authenticateWithAToken = this.current.jsonData.authenticateWithAToken || false;
   }
 }
 

--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -6,7 +6,7 @@ export class HumioConfigCtrl {
     this.current = this.current || {};
     this.current.jsonData = this.current.jsonData || {};
     this.current.jsonData.baseUrl = this.current.jsonData.baseUrl || "";
-    this.current.jsonData.tokenAuth = this.current.jsonData.tokenAuth || false;
+    this.current.jsonData.tokenAuth = this.current.jsonData.authenticateWithAToken || false;
   }
 }
 

--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -6,6 +6,9 @@ export class HumioConfigCtrl {
     this.current = this.current || {};
     this.current.jsonData = this.current.jsonData || {};
     this.current.jsonData.baseUrl = this.current.jsonData.baseUrl || "";
+    this.current.jsonData.tokenAuth = this.current.jsonData.tokenAuth || false;
+
+
   }
 }
 

--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -7,8 +7,6 @@ export class HumioConfigCtrl {
     this.current.jsonData = this.current.jsonData || {};
     this.current.jsonData.baseUrl = this.current.jsonData.baseUrl || "";
     this.current.jsonData.tokenAuth = this.current.jsonData.tokenAuth || false;
-
-
   }
 }
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -72,21 +72,19 @@ export class HumioDatasource {
    * Implicitly called by Grafana when user clicks the "Save & Test" button during data source configuration.
    */
   testDatasource() {
-    let requestOpts : IDatasourceRequestOptions;
+    let requestOpts : IDatasourceRequestOptions = 
+    {
+      url: this.proxy_url,
+      method: "POST",
+      data: { query: '{currentUser{id}}' } 
+    };
+
     if(this.tokenAuth){
-      requestOpts = {
-        url: this.proxy_url + "/humio/graphql",
-        method: "POST",
-        data: { query: '{currentUser{id}}' } 
-      }
+      requestOpts.url += "/humio/graphql";
     }
     else{
-      requestOpts = {
-        method: 'POST',
-        url: this.proxy_url + '/graphql',
-        headers: this.headers,
-        data: { query: '{currentUser{id}}' }, 
-      }
+      requestOpts.url += '/graphql';
+      requestOpts.headers = this.headers;
     }
 
     return this.datasourceAttrs.backendSrv

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -2,6 +2,7 @@
 import IDatasourceAttrs from './Interfaces/IDatasourceAttrs';
 import IGrafanaAttrs from './Interfaces/IGrafanaAttrs';
 import IDatasourceRequestOptions from './Interfaces/IDatasourceRequestOptions';
+import IDatasourceRequestHeaders from './Interfaces/IDatasourceRequestHeaders';
 import QueryJobManager from './humio/query_job_manager';
 
 /**
@@ -12,15 +13,15 @@ export class HumioDatasource {
   id: string;
   datasourceAttrs: IDatasourceAttrs;
   timeRange: any;
-  tokenAuth: false;
+  authenticateWithAToken: false;
   humioToken : string;
-  headers: any; // TODO: Request Headers again
+  headers: IDatasourceRequestHeaders;
 
   /** @ngInject */
   constructor(instanceSettings, $q, backendSrv, $location, $rootScope) {
     this.proxy_url = instanceSettings.url;
     this.id = instanceSettings.id;
-    this.tokenAuth = instanceSettings.jsonData.tokenAuth;
+    this.authenticateWithAToken = instanceSettings.jsonData.tokenAuth;
     
     let humioToken = instanceSettings.jsonData ? instanceSettings.jsonData.humioToken || ''  : ''
     this.headers = {
@@ -37,8 +38,6 @@ export class HumioDatasource {
 
     this.timeRange = null;
     this._doRequest = this._doRequest.bind(this);
-
-
   }
 
   /**
@@ -79,7 +78,7 @@ export class HumioDatasource {
       data: { query: '{currentUser{id}}' } 
     };
 
-    if(this.tokenAuth){
+    if(this.authenticateWithAToken){
       requestOpts.url += "/humio/graphql";
     }
     else{
@@ -116,7 +115,7 @@ export class HumioDatasource {
 
   private _doRequest(options) {
     
-    if(!this.tokenAuth){
+    if(!this.authenticateWithAToken){
       options.headers = this.headers;
       options.url = this.proxy_url + options.url;
     }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -12,11 +12,13 @@ export class HumioDatasource {
   id: string;
   datasourceAttrs: IDatasourceAttrs;
   timeRange: any;
+  tokenAuth: false;
 
   /** @ngInject */
   constructor(instanceSettings, $q, backendSrv, $location, $rootScope) {
     this.proxy_url = instanceSettings.url;
     this.id = instanceSettings.id;
+    this.tokenAuth = instanceSettings.jsonData.tokenAuth;
     
     this.datasourceAttrs = {
       $q: $q,

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -23,10 +23,8 @@ export class HumioDatasource {
     this.id = instanceSettings.id;
     this.authenticateWithAToken = instanceSettings.jsonData.tokenAuth;
     
-    let humioToken = instanceSettings.jsonData ? instanceSettings.jsonData.humioToken || ''  : ''
     this.headers = {
-      'Content-Type': 'application/json',
-      Authorization: 'Bearer ' + humioToken,
+      'Content-Type': 'application/json'
     };
     
     this.datasourceAttrs = {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -21,7 +21,7 @@ export class HumioDatasource {
   constructor(instanceSettings, $q, backendSrv, $location, $rootScope) {
     this.proxy_url = instanceSettings.url;
     this.id = instanceSettings.id;
-    this.authenticateWithAToken = instanceSettings.jsonData.tokenAuth;
+    this.authenticateWithAToken = instanceSettings.jsonData.authenticateWithAToken;
     
     this.headers = {
       'Content-Type': 'application/json'

--- a/src/humio/query_job.ts
+++ b/src/humio/query_job.ts
@@ -34,6 +34,7 @@ class QueryJob {
 
     const requestedQueryDefinition = this._getRequestedQueryDefinition(datasourceAttrs, grafanaAttrs, target);
 
+    // Executing the same live query again
     if(this.queryId && !this._queryDefinitionHasChanged(requestedQueryDefinition)){
       return this._pollQueryJobUntilDone(datasourceAttrs, grafanaAttrs, target);
     }
@@ -138,7 +139,7 @@ class QueryJob {
             resolve(res);
           } else {
             var waitTimeUntilNextPoll = res['data']['metaData']['pollAfter'];
-            setTimeout(() => {recursivePollingFunc();}, waitTimeUntilNextPoll); // If we don't wait the stated amount, Humio will return the same data again.
+            setTimeout(() => {recursivePollingFunc();}, 40220); // If we don't wait the stated amount, Humio will return the same data again.
           }
         });
       };

--- a/src/humio/query_job.ts
+++ b/src/humio/query_job.ts
@@ -139,7 +139,7 @@ class QueryJob {
             resolve(res);
           } else {
             var waitTimeUntilNextPoll = res['data']['metaData']['pollAfter'];
-            setTimeout(() => {recursivePollingFunc();}, 40220); // If we don't wait the stated amount, Humio will return the same data again.
+            setTimeout(() => {recursivePollingFunc();}, waitTimeUntilNextPoll); // If we don't wait the stated amount, Humio will return the same data again.
           }
         });
       };

--- a/src/partials/config.pug
+++ b/src/partials/config.pug
@@ -1,4 +1,4 @@
-p With this plugin you may authenticate using two overall strategies. Pick the strategy you want to use using the toggle below.
+p With this plugin you may authenticate using one of two overall strategies. Pick the strategy you want to use using the toggle below.
 
 
 // TODO: Graphic, doesn't always follow.
@@ -8,10 +8,10 @@ p With this plugin you may authenticate using two overall strategies. Pick the s
       label.gf-form.gf-form-switch-container(for="auth_strategy") 
         .gf-form-label.pointer Authentication Strategy
         .gf-form-switch
-          input#auth_strategy(type="checkbox" ng-model="ctrl.current.jsonData.tokenAuth" onclick='switchAuthStrategy()')
+          input#auth_strategy(type="checkbox" ng-model="ctrl.current.jsonData.tokenAuth" onchange="switchAuthStrategy()")  
           span.gf-form-switch__slider
 
-div#no_token 
+div#no_token(ng-show="!ctrl.current.jsonData.tokenAuth")
   h3 Authenticate Without API Tokens 
   p This authentication strategy allows you to authenticate without an API token. It's commonly used for Oauth based authentication.
 
@@ -21,11 +21,10 @@ div#no_token
   .gf-form
     input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.humioToken', placeholder="")
 
-div#token 
+div#token(ng-show="ctrl.current.jsonData.tokenAuth")
   h3 Authenticate With Encrypted API Tokens 
   p This authentication strategy allows you to authenticate with a personal API token. 
-  p Note that the token is encrypted and stored on Grafana's backend, so you can't access it via the browser after entry. br
-    This also means that all requests to Humio will be proxied through the Grafana server instance.
+  p Note that the token is encrypted and stored on Grafana's backend, so you can't access it via the browser after entry. This also means that all requests to Humio will be proxied through the Grafana server instance.
 
   h5 Humio Url
   .gf-form
@@ -43,7 +42,7 @@ script.
     var non_token_elements = document.getElementById("no_token");
     var token_elements = document.getElementById("token");
     var authenticate_with_tokens = document.getElementById("auth_strategy").checked;
-    console.log(authenticate_with_tokens);
+    console.log(document.getElementById("auth_strategy"));
 
     if(authenticate_with_tokens){
       token_elements.style.display = "block";
@@ -54,5 +53,3 @@ script.
       non_token_elements.style.display = "block";
     }
   } 
-
-  switchAuthStrategy();

--- a/src/partials/config.pug
+++ b/src/partials/config.pug
@@ -1,9 +1,43 @@
-h5 Humio Url
-.gf-form
-  input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.baseUrl', placeholder="https://cloud.humio.com")
 
-h5 Humio Access Token
-.gf-form
-  input.gf-form-input(type="text",   tooltip="Grafana Proxy deletes fo",  ng-model='ctrl.current.secureJsonData.humioToken')
+.gf-form-group
+  .gf-form-inline
+    .gf-form-switch-container-react
+      label.gf-form.gf-form-switch-container(for="test") 
+        .gf-form-label.pointer Authentication Strategy
+        .gf-form-switch
+          input#test(type="checkbox" ng-model="ctrl.current.jsonData.tokenAuth" onclick='clickme()')
+          span.gf-form-switch__slider
 
-p Once the datasource is saved the contents of the 'Humio Access Token' field will be hidden. The datasource will continue to use the submitted token until it is changed. 
+
+div#encrypted Encrypted Tokens 
+  h5 Humio Url
+  .gf-form
+    input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.baseUrl', placeholder="https://cloud.humio.com")
+
+  h5 Humio Access Token
+  .gf-form
+    input.gf-form-input(type="text",  ng-model='ctrl.current.secureJsonData.humioToken')
+
+  p Once the datasource is saved the contents of the 'Humio Access Token' field will be hidden. The datasource will continue to use the submitted token until it is changed. 
+
+div#regular Regular
+  datasource-http-settings(current="ctrl.current", suggest-url="https://cloud.humio.com")
+
+
+script.
+  var x = document.getElementById("encrypted");
+  var y = document.getElementById("regular");
+  x.style.display = "block";
+  y.style.display = "none";
+
+  function clickme() {
+  var x = document.getElementById("encrypted");
+  var y = document.getElementById("regular");
+  if (x.style.display === "none") {
+    x.style.display = "block";
+    y.style.display = "none";
+  } else {
+    x.style.display = "none";
+    y.style.display = "block";
+  }
+  } 

--- a/src/partials/config.pug
+++ b/src/partials/config.pug
@@ -8,7 +8,7 @@ p With this plugin you may authenticate using one of two overall strategies. Pic
       label.gf-form.gf-form-switch-container(for="auth_strategy") 
         .gf-form-label.pointer Authentication Strategy
         .gf-form-switch
-          input#auth_strategy(type="checkbox" ng-model="ctrl.current.jsonData.authenticateWithAToken" onchange="switchAuthStrategy()")  
+          input#auth_strategy(type="checkbox" ng-model="ctrl.current.jsonData.authenticateWithAToken")  
           span.gf-form-switch__slider
 
 div#no_token(ng-show="!ctrl.current.jsonData.authenticateWithAToken")
@@ -35,21 +35,3 @@ div#token(ng-show="ctrl.current.jsonData.authenticateWithAToken")
     input.gf-form-input(type="text",  ng-model='ctrl.current.secureJsonData.humioToken')
 
   p Once the datasource is saved the contents of the 'Humio Access Token' field will be hidden. The datasource will continue to use the submitted token until it is changed. 
-
-
-script.
-  function switchAuthStrategy() {
-    var non_token_elements = document.getElementById("no_token");
-    var token_elements = document.getElementById("token");
-    var authenticate_with_tokens = document.getElementById("auth_strategy").checked;
-    console.log(document.getElementById("auth_strategy"));
-
-    if(authenticate_with_tokens){
-      token_elements.style.display = "block";
-      non_token_elements.style.display = "none";
-    }
-    else{
-      token_elements.style.display = "none";
-      non_token_elements.style.display = "block";
-    }
-  } 

--- a/src/partials/config.pug
+++ b/src/partials/config.pug
@@ -1,15 +1,32 @@
+p With this plugin you may authenticate using two overall strategies. Pick the strategy you want to use using the toggle below.
 
+
+// TODO: Graphic, doesn't always follow.
 .gf-form-group
   .gf-form-inline
     .gf-form-switch-container-react
-      label.gf-form.gf-form-switch-container(for="test") 
+      label.gf-form.gf-form-switch-container(for="auth_strategy") 
         .gf-form-label.pointer Authentication Strategy
         .gf-form-switch
-          input#test(type="checkbox" ng-model="ctrl.current.jsonData.tokenAuth" onclick='clickme()')
+          input#auth_strategy(type="checkbox" ng-model="ctrl.current.jsonData.tokenAuth" onclick='switchAuthStrategy()')
           span.gf-form-switch__slider
 
+div#no_token 
+  h3 Authenticate Without API Tokens 
+  p This authentication strategy allows you to authenticate without an API token. It's commonly used for Oauth based authentication.
 
-div#encrypted Encrypted Tokens 
+  datasource-http-settings(current="ctrl.current", suggest-url="https://cloud.humio.com")
+
+  h5 Humio access token
+  .gf-form
+    input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.humioToken', placeholder="")
+
+div#token 
+  h3 Authenticate With Encrypted API Tokens 
+  p This authentication strategy allows you to authenticate with a personal API token. 
+  p Note that the token is encrypted and stored on Grafana's backend, so you can't access it via the browser after entry. br
+    This also means that all requests to Humio will be proxied through the Grafana server instance.
+
   h5 Humio Url
   .gf-form
     input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.baseUrl', placeholder="https://cloud.humio.com")
@@ -20,37 +37,22 @@ div#encrypted Encrypted Tokens
 
   p Once the datasource is saved the contents of the 'Humio Access Token' field will be hidden. The datasource will continue to use the submitted token until it is changed. 
 
-div#regular Regular
-  datasource-http-settings(current="ctrl.current", suggest-url="https://cloud.humio.com")
-
-  h5 Humio access token
-  .gf-form
-    input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.humioToken', placeholder="")
-
 
 script.
-  var x = document.getElementById("encrypted");
-  var y = document.getElementById("regular");
-  var test = document.getElementById("test");
-  console.log(test);
+  function switchAuthStrategy() {
+    var non_token_elements = document.getElementById("no_token");
+    var token_elements = document.getElementById("token");
+    var authenticate_with_tokens = document.getElementById("auth_strategy").checked;
+    console.log(authenticate_with_tokens);
 
-  if(test.checked){
-    x.style.display = "block";
-    y.style.display = "none";
-  }
-  else{
-    x.style.display = "none";
-    y.style.display = "block";
+    if(authenticate_with_tokens){
+      token_elements.style.display = "block";
+      non_token_elements.style.display = "none";
     }
-
-  function clickme() {
-  var x = document.getElementById("encrypted");
-  var y = document.getElementById("regular");
-  if (x.style.display === "none") {
-    x.style.display = "block";
-    y.style.display = "none";
-  } else {
-    x.style.display = "none";
-    y.style.display = "block";
-  }
+    else{
+      token_elements.style.display = "none";
+      non_token_elements.style.display = "block";
+    }
   } 
+
+  switchAuthStrategy();

--- a/src/partials/config.pug
+++ b/src/partials/config.pug
@@ -23,12 +23,25 @@ div#encrypted Encrypted Tokens
 div#regular Regular
   datasource-http-settings(current="ctrl.current", suggest-url="https://cloud.humio.com")
 
+  h5 Humio access token
+  .gf-form
+    input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.humioToken', placeholder="")
+
 
 script.
   var x = document.getElementById("encrypted");
   var y = document.getElementById("regular");
-  x.style.display = "block";
-  y.style.display = "none";
+  var test = document.getElementById("test");
+  console.log(test);
+
+  if(test.checked){
+    x.style.display = "block";
+    y.style.display = "none";
+  }
+  else{
+    x.style.display = "none";
+    y.style.display = "block";
+    }
 
   function clickme() {
   var x = document.getElementById("encrypted");

--- a/src/partials/config.pug
+++ b/src/partials/config.pug
@@ -8,10 +8,10 @@ p With this plugin you may authenticate using one of two overall strategies. Pic
       label.gf-form.gf-form-switch-container(for="auth_strategy") 
         .gf-form-label.pointer Authentication Strategy
         .gf-form-switch
-          input#auth_strategy(type="checkbox" ng-model="ctrl.current.jsonData.tokenAuth" onchange="switchAuthStrategy()")  
+          input#auth_strategy(type="checkbox" ng-model="ctrl.current.jsonData.authenticateWithAToken" onchange="switchAuthStrategy()")  
           span.gf-form-switch__slider
 
-div#no_token(ng-show="!ctrl.current.jsonData.tokenAuth")
+div#no_token(ng-show="!ctrl.current.jsonData.authenticateWithAToken")
   h3 Authenticate Without API Tokens 
   p This authentication strategy allows you to authenticate without an API token. It's commonly used for Oauth based authentication.
 
@@ -21,7 +21,7 @@ div#no_token(ng-show="!ctrl.current.jsonData.tokenAuth")
   .gf-form
     input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.humioToken', placeholder="")
 
-div#token(ng-show="ctrl.current.jsonData.tokenAuth")
+div#token(ng-show="ctrl.current.jsonData.authenticateWithAToken")
   h3 Authenticate With Encrypted API Tokens 
   p This authentication strategy allows you to authenticate with a personal API token. 
   p Note that the token is encrypted and stored on Grafana's backend, so you can't access it via the browser after entry. This also means that all requests to Humio will be proxied through the Grafana server instance.

--- a/src/partials/config.pug
+++ b/src/partials/config.pug
@@ -17,10 +17,6 @@ div#no_token(ng-show="!ctrl.current.jsonData.authenticateWithAToken")
 
   datasource-http-settings(current="ctrl.current", suggest-url="https://cloud.humio.com")
 
-  h5 Humio access token
-  .gf-form
-    input.gf-form-input(type="text", ng-model='ctrl.current.jsonData.humioToken', placeholder="")
-
 div#token(ng-show="ctrl.current.jsonData.authenticateWithAToken")
   h3 Authenticate With Encrypted API Tokens 
   p This authentication strategy allows you to authenticate with a personal API token. 

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -81,7 +81,7 @@ class HumioQueryCtrl extends QueryCtrl {
       data: { query: '{searchDomains{name}}' }
     };
 
-    if(this.datasource.tokenAuth){
+    if(this.datasource.authenticateWithAToken){
       requestOpts.url += "/humio/graphql"
     }
     else

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -75,10 +75,23 @@ class HumioQueryCtrl extends QueryCtrl {
       return this.$q.when([]);
     }
 
-    const requestOpts: IDatasourceRequestOptions = {
-      method: 'POST',
-      url: this.datasource.proxy_url + "/humio/graphql",
-      data: { query: '{searchDomains{name}}' },
+    let requestOpts : IDatasourceRequestOptions;
+
+    if(this.datasource.tokenAuth){
+      requestOpts = {
+        method: 'POST',
+        url: this.datasource.proxy_url + "/humio/graphql",
+        data: { query: '{searchDomains{name}}' },
+      }
+    }
+    else
+    {
+      requestOpts = {
+        method: 'POST',
+        url: this.datasource.proxy_url + '/graphql',
+        headers: this.datasource.headers,
+        data: { query: '{searchDomains{name}}' }, 
+      }
     }
 
     return this.datasource.datasourceAttrs.backendSrv

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -75,23 +75,19 @@ class HumioQueryCtrl extends QueryCtrl {
       return this.$q.when([]);
     }
 
-    let requestOpts : IDatasourceRequestOptions;
+    let requestOpts : IDatasourceRequestOptions = {
+      method: 'POST',
+      url: this.datasource.proxy_url,
+      data: { query: '{searchDomains{name}}' }
+    };
 
     if(this.datasource.tokenAuth){
-      requestOpts = {
-        method: 'POST',
-        url: this.datasource.proxy_url + "/humio/graphql",
-        data: { query: '{searchDomains{name}}' },
-      }
+      requestOpts.url += "/humio/graphql"
     }
     else
     {
-      requestOpts = {
-        method: 'POST',
-        url: this.datasource.proxy_url + '/graphql',
-        headers: this.datasource.headers,
-        data: { query: '{searchDomains{name}}' }, 
-      }
+      requestOpts.url += '/graphql';
+      requestOpts.headers = this.datasource.headers;
     }
 
     return this.datasource.datasourceAttrs.backendSrv


### PR DESCRIPTION
#Reintroducing OAUTH

**What Changes Have Been Made?**
Plugin now supports both auth with OAUTH (which was removed previously) and encrypted tokens.

**Why Have the Changes Been Made?**
Some users still needed the OAUTH feature so it was added back.

**How Do These Changes Impact the User?**
The user will now have to select what auth method to use when creating a data source. Will most likely require users to save their data sources again after upgrade.
