### PR TITLE
Issue/53/enhancements

### DIFF
--- a/src/HumioDataSource.ts
+++ b/src/HumioDataSource.ts
@@ -140,12 +140,12 @@ export class HumioDataSource extends DataSourceApi<HumioQuery, HumioOptions> {
     let targets: HumioQuery[] = [];
     targets.push(query);
 
-    let textField = !options.annotation.annotationText ? '' : options.annotation.annotationText;
+    let annotationText = !options.annotation.annotationText ? '' : options.annotation.annotationText;
 
     // Make query to Humio.
     let queryJobManager = QueryJobManager.getOrCreateQueryJobManager(options.annotation.refId.toString());
     const queryResponse = (await queryJobManager.update(location, grafanaAttrs, targets))[0]; // Annotation query only has one target
-    return QueryResultFormatter.formatAnnotationQueryResponse(queryResponse.data, textField);
+    return QueryResultFormatter.formatAnnotationQueryResponse(queryResponse.data, annotationText);
   }
 
   testDatasource() {

--- a/src/partials/annotations.editor.html
+++ b/src/partials/annotations.editor.html
@@ -18,7 +18,7 @@
     </select>
   </div>
   <label>
-    Event Field to Use For Annotation Text
+    Annotation Text - Use {field} to refenrence event fields. 
   </label>
   <div class="gf-form gf-form--grow">
     <input

--- a/src/partials/annotations.editor.html
+++ b/src/partials/annotations.editor.html
@@ -9,7 +9,6 @@
   <label>
     Humio repository
   </label>
-
   <div class="gf-form gf-form--grow">
     <select class="gf-form-input.gf-size-auto"
               ng-model="ctrl.annotation.humioRepository",
@@ -18,12 +17,12 @@
     </select>
   </div>
   <label>
-    Annotation Text - Use {field} to refenrence event fields. 
+    Annotation text - use {field} to reference an event field. 
   </label>
   <div class="gf-form gf-form--grow">
     <input
      class="gf-form-input"
-     placeholder="annotation text"
+     placeholder="E.g. {service} is {status}!"
      ng-model="ctrl.annotation.annotationText"
      ></input>
   </div>


### PR DESCRIPTION
# Support for multiple event fields in the annotation text

**What Changes Have Been Made?**

The plugin now supports using a more flexible annotation text describing each annotation as a customizable string with multiple event fields can be used. 

**Why Have the Changes Been Made?**

The former implementation only used one event field as the annotation text, which was a problem if a user used more than one annotation at once displaying the same event field in their annotation text. The annotation text can thus now be more uniquely assembled for each annotation created. 

**How Do These Changes Impact the User?**

The changes will not require the user to make any adaptations to their current project. 
