### PR TITLE
Non-token auth frontend fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,21 @@ Update to Datasource Configuration. This update requires existing data sources t
 
 ### Removed
 - Some standard data source configuration options. These had to be removed in order to configure datasources for encrypted access tokens.
+
+## 3.0.0 (2020-07-16)
+Major update which rewrites the plugin to use React rather than AngularJS
+### Added 
+- Support for variables
+- Support for annotations
+
+### Changed
+- Fixed bug where humio query links would not work, if the datasource URL did not have a trailing slash.
+
+### Removed
+- Old tests
+
+## 3.0.1 (2020-07-21)
+Patch which allows users to use non-token auth for data sources again.
+
+### Changed
+- Updated data source config to allow users more types of authentication.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "humio2grafana-datasource",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Grafana datasource for Humio",
   "main": "module.ts",
   "repository": "git@github.com:humio/humio2grafana.git",

--- a/src/HumioConfigEditor.tsx
+++ b/src/HumioConfigEditor.tsx
@@ -16,8 +16,6 @@ export class ConfigEditor extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    console.log(props);
-
     props.options.jsonData = { ...props.options.jsonData };
 
     this.state = {

--- a/src/HumioConfigEditor.tsx
+++ b/src/HumioConfigEditor.tsx
@@ -17,6 +17,10 @@ export class ConfigEditor extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
+    console.log(props);
+
+    props.options.jsonData = { ...props.options.jsonData };
+
     this.state = {
       humioToken: props.options.jsonData.humioToken,
       props: props,
@@ -34,14 +38,27 @@ export class ConfigEditor extends PureComponent<Props, State> {
           using the toggle below.
         </p>
         <Switch
-          label="Authentication Strategy "
+          label="Authentication Strategy"
           checked={options.jsonData.tokenAuth}
-          onChange={_ =>
+          onChange={_ => {
             onOptionsChange({
               ...options,
-              jsonData: { ...options.jsonData, tokenAuth: !options.jsonData.tokenAuth },
-            })
-          }
+              withCredentials: false,
+              basicAuth: false,
+              basicAuthPassword: '',
+              basicAuthUser: '',
+              jsonData: {
+                ...options.jsonData,
+                tokenAuth: !options.jsonData.tokenAuth,
+                // TODO: This ensures that we don't try to do the non-token auth, such as using a CACert when using a token. But this also resets parts of the non-token form. Try to find a better way.
+                tlsAuth: false,
+                tlsSkipVerify: false,
+                tlsAuthWithCACert: false,
+                oauthPassThru: false,
+              },
+              secureJsonFields: {},
+            });
+          }}
         />
         <p></p>
       </>
@@ -134,33 +151,10 @@ export class ConfigEditor extends PureComponent<Props, State> {
             onChange={newValue =>
               onOptionsChange({
                 ...newValue,
-                jsonData: { ...options.jsonData },
-                secureJsonData: { ...options.secureJsonData },
-                secureJsonFields: { ...options.secureJsonFields },
+                jsonData: { ...newValue.jsonData, tokenAuth: false },
               })
             }
           />
-
-          <h3 className="page-heading">Password</h3>
-          <div className="gf-form-group">
-            <div className="gf-form-inline">
-              <div className="gf-form max-width-25">
-                <FormField
-                  labelWidth={10}
-                  inputWidth={15}
-                  label="Token"
-                  value={options.jsonData.humioToken}
-                  onChange={newValue =>
-                    onOptionsChange({
-                      ...options,
-                      jsonData: { ...options.jsonData, humioToken: newValue.currentTarget.value },
-                    })
-                  }
-                  required
-                />
-              </div>
-            </div>
-          </div>
         </>
       );
     }

--- a/src/HumioConfigEditor.tsx
+++ b/src/HumioConfigEditor.tsx
@@ -2,14 +2,13 @@ import React, { PureComponent } from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { DataSourceHttpSettings, LegacyForms } from '@grafana/ui';
 
-const { FormField, SecretFormField, Switch } = LegacyForms;
+const { SecretFormField } = LegacyForms;
 
 import { HumioOptions, SecretHumioOptions } from './types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<HumioOptions, SecretHumioOptions> {}
 
 interface State {
-  humioToken?: string;
   props: any;
 }
 
@@ -22,150 +21,80 @@ export class ConfigEditor extends PureComponent<Props, State> {
     props.options.jsonData = { ...props.options.jsonData };
 
     this.state = {
-      humioToken: props.options.jsonData.humioToken,
       props: props,
     };
   }
 
   componentDidMount() {}
 
-  commonHeader() {
-    const { options, onOptionsChange } = this.props;
-    return (
-      <>
-        <p>
-          With this plugin you may authenticate using one of two overall strategies. Pick the strategy you want to use
-          using the toggle below.
-        </p>
-        <Switch
-          label="Authentication Strategy"
-          checked={options.jsonData.tokenAuth}
-          onChange={_ => {
-            onOptionsChange({
-              ...options,
-              withCredentials: false,
-              basicAuth: false,
-              basicAuthPassword: '',
-              basicAuthUser: '',
-              jsonData: {
-                ...options.jsonData,
-                tokenAuth: !options.jsonData.tokenAuth,
-                // TODO: This ensures that we don't try to do the non-token auth, such as using a CACert when using a token. But this also resets parts of the non-token form. Try to find a better way.
-                tlsAuth: false,
-                tlsSkipVerify: false,
-                tlsAuthWithCACert: false,
-                oauthPassThru: false,
-              },
-              secureJsonFields: {},
-            });
-          }}
-        />
-        <p></p>
-      </>
-    );
-  }
-
   onPasswordReset = () => {
     const { options, onOptionsChange } = this.props;
     onOptionsChange({
       ...options,
-      jsonData: { ...options.jsonData },
-      secureJsonData: {
-        humioToken: '',
-      },
-      secureJsonFields: {
-        humioToken: false,
-      },
+      jsonData: { ...options.jsonData, authenticateWithToken: false },
+      secureJsonData: undefined,
+      secureJsonFields: undefined,
     });
   };
 
   body() {
     const { options, onOptionsChange } = this.props;
-    if (options.jsonData.tokenAuth) {
-      return (
-        <>
-          <h3 className="page-heading">Authenticate With Encrypted API Tokens </h3>
-          <p> This authentication strategy allows you to authenticate with a personal API token. </p>
+    return (
+      <>
+        <p>
+          To authenticate against Humio, you may either use the standard authentication methods as provided by Grafana
+          under <b>Auth</b>, or use a Humio token under <b>Humio Token Authentication</b>. There should be no reason to
+          mix these two methods for authentication, so be mindfuld not to configure both.
+        </p>
+
+        <DataSourceHttpSettings
+          defaultUrl={'https://cloud.humio.com'}
+          dataSourceConfig={options}
+          showAccessOptions={false}
+          onChange={newValue =>
+            onOptionsChange({
+              ...newValue,
+              jsonData: {
+                ...newValue.jsonData,
+                baseUrl: newValue.url,
+                authenticateWithToken: options.jsonData.authenticateWithToken,
+              },
+            })
+          }
+        />
+        <div className="gf-form-group">
+          <h5> Humio Token Authentication </h5>
           <p>
             {' '}
-            Note that the token is encrypted and stored on Grafana's backend, so you can't access it via the browser
-            after entry. This also means that all requests to Humio will be proxied through the Grafana server instance.{' '}
+            If you wish to authenticate using a personal Humio token copy and paste it into the field below. <br></br>
           </p>
-          <div className="gf-form-group">
-            <div className="gf-form max-width-25">
-              <FormField
-                labelWidth={10}
-                inputWidth={15}
-                label="URL"
-                value={options.jsonData.baseUrl}
-                onChange={newValue =>
-                  onOptionsChange({
-                    ...options,
-                    jsonData: {
-                      ...options.jsonData,
-                      baseUrl: newValue.currentTarget.value,
-                    },
-                    secureJsonData: { ...options.secureJsonData },
-                  })
-                }
-                required
-              />
-            </div>
+          <div className="gf-form max-width-25">
+            <SecretFormField
+              labelWidth={10}
+              inputWidth={15}
+              label="Token"
+              value={options.secureJsonData?.humioToken}
+              onChange={newValue =>
+                onOptionsChange({
+                  ...options,
+                  jsonData: {
+                    baseUrl: options.jsonData.baseUrl,
+                    authenticateWithToken: true,
+                  },
+                  secureJsonData: { humioToken: newValue.currentTarget.value },
+                })
+              }
+              isConfigured={options.jsonData.authenticateWithToken}
+              onReset={this.onPasswordReset}
+              required={false}
+            />
           </div>
-          <div className="gf-form-group">
-            <div className="gf-form max-width-25">
-              <SecretFormField
-                labelWidth={10}
-                inputWidth={15}
-                label="Token"
-                value={options.secureJsonData?.humioToken}
-                onChange={newValue =>
-                  onOptionsChange({
-                    ...options,
-                    jsonData: {
-                      humioToken: options.jsonData.humioToken,
-                      tokenAuth: options.jsonData.tokenAuth,
-                      baseUrl: options.jsonData.baseUrl,
-                    },
-                    secureJsonData: { humioToken: newValue.currentTarget.value },
-                  })
-                }
-                isConfigured={!!(options.secureJsonFields && options.secureJsonFields.humioToken)}
-                onReset={this.onPasswordReset}
-                required
-              />
-            </div>
-          </div>
-        </>
-      );
-    } else {
-      return (
-        <>
-          <h3 className="page-heading">Authenticate Without API Tokens </h3>
-          <p> This authentication strategy allows you to authenticate without an API token. </p>
-
-          <DataSourceHttpSettings
-            defaultUrl={'https://cloud.humio.com'}
-            dataSourceConfig={options}
-            showAccessOptions={false}
-            onChange={newValue =>
-              onOptionsChange({
-                ...newValue,
-                jsonData: { ...newValue.jsonData, tokenAuth: false },
-              })
-            }
-          />
-        </>
-      );
-    }
+        </div>
+      </>
+    );
   }
 
   render() {
-    return (
-      <>
-        {this.commonHeader()}
-        {this.body()}
-      </>
-    );
+    return <>{this.body()}</>;
   }
 }

--- a/src/HumioDataSource.ts
+++ b/src/HumioDataSource.ts
@@ -55,17 +55,9 @@ export class HumioDataSource extends DataSourceApi<HumioQuery, HumioOptions> {
     }
 
     this.id = instanceSettings.id;
-
-    if (this.authenticateWithAToken) {
-      this.headers = {
-        'Content-Type': 'application/json',
-      };
-    } else {
-      this.headers = {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer ' + instanceSettings.jsonData.humioToken,
-      };
-    }
+    this.headers = {
+      'Content-Type': 'application/json',
+    };
   }
 
   async metricFindQuery(query: any, options: any): Promise<MetricFindValue[]> {

--- a/src/HumioDataSource.ts
+++ b/src/HumioDataSource.ts
@@ -32,13 +32,13 @@ export class HumioDataSource extends DataSourceApi<HumioQuery, HumioOptions> {
   rest_endpoint: string;
   id: number;
   timeRange: any;
-  authenticateWithAToken: boolean;
   headers: DatasourceRequestHeaders;
+  authenticateWithAToken: boolean;
 
   constructor(instanceSettings: DataSourceInstanceSettings<HumioOptions>) {
     super(instanceSettings);
 
-    this.authenticateWithAToken = instanceSettings.jsonData.tokenAuth;
+    this.authenticateWithAToken = instanceSettings.jsonData.authenticateWithToken;
 
     if (instanceSettings.url === undefined) {
       this.proxy_url = '';

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -16,7 +16,7 @@
         "small": "img/humio_logo.svg",
         "large": "img/humio_logo.svg"
       },
-      "version": "3.0.0",
+      "version": "3.0.1",
       "updated": "2020-07-xx"
     },
     "routes": [{

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,10 @@ export interface HumioOptions extends DataSourceJsonData {
   baseUrl?: string;
   tokenAuth: boolean;
   humioToken?: string;
+  tlsAuth?: boolean;
+  tlsAuthWithCACert?: boolean;
+  tlsSkipVerify?: boolean;
+  oauthPassThru?: boolean;
 }
 
 export interface SecretHumioOptions extends DataSourceJsonData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,12 +2,7 @@ import { DataSourceJsonData } from '@grafana/data';
 
 export interface HumioOptions extends DataSourceJsonData {
   baseUrl?: string;
-  tokenAuth: boolean;
-  humioToken?: string;
-  tlsAuth?: boolean;
-  tlsAuthWithCACert?: boolean;
-  tlsSkipVerify?: boolean;
-  oauthPassThru?: boolean;
+  authenticateWithToken: boolean;
 }
 
 export interface SecretHumioOptions extends DataSourceJsonData {


### PR DESCRIPTION
# <Feature Title>

Link To Issue Being Solved: No Issue Created

**What Changes Have Been Made?**
Can now authenticate without the use of a token

**Why Have the Changes Been Made?**
This used to be possible but a bug removed that ability when bumping to 3.0.0

**How Do These Changes Impact the User?**
User may need to redefine some of their data sources after updating.
