### PR TITLE
AnnotationQuery working now with no lookahead

### DIFF
--- a/src/humio/query_result_formatter.ts
+++ b/src/humio/query_result_formatter.ts
@@ -22,10 +22,12 @@ class QueryResultFormatter {
       }
 
       // Extract all fields from the annotation text.
-      const regexp = /(?<=\{).+?(?=\})/g;
-      let textFields = annotationText.match(regexp);
+      const regexp = /\{(.+?)\}/g;
+      let textFields = annotationText.match(regexp)?.map((field: string) => {
+        return field.substring(1, field.length - 1);
+      });
 
-      if (textFields === null) {
+      if (textFields === null || textFields === undefined) {
         textFields = [];
       }
 


### PR DESCRIPTION
# <Feature Title>

Link To Issue Being Solved: No issue created

**What Changes Have Been Made?**

Annotation Query doesn't match fields with regex lookbehind anymore.

**Why Have the Changes Been Made?**

Safari doesn't support the lookbehind feature of Regex, meaning that the Plugin didn't work in that browser.

**How Do These Changes Impact the User?**

This should have no user impact.
