### PR TITLE
Small Regex Fix

### DIFF
--- a/src/HumioDataSource.ts
+++ b/src/HumioDataSource.ts
@@ -69,10 +69,9 @@ export class HumioDataSource extends DataSourceApi<HumioQuery, HumioOptions> {
   formatting(vars: any) {
     if (_.isString(vars) || vars.length === 1) {
       // Regular variables are input as strings, while the input is an array when Multi-value variables are used.
-      return _.escapeRegExp(vars);
+      return vars;
     } else {
-      let args = vars.map((v: string) => _.escapeRegExp(v));
-      return '/^' + args.join('|') + '$/';
+      return '/^' + vars.join('|') + '$/';
     }
   }
 


### PR DESCRIPTION
# <Feature Title>

Link To Issue Being Solved: No Issues

**What Changes Have Been Made?**
Removes regex escaping, as there are cases where this changes semantics of legal queries

**Why Have the Changes Been Made?**

Weren't able to have variable names like "example.com" as the formatting would turn it into "example//.com"

**How Do These Changes Impact the User?**

No impact, but we need to return to this and see if there's a way to secure queries.
